### PR TITLE
Support for searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ vendor/
 .idea/**/tasks.xml
 .idea/**/dictionaries
 .idea/**/shelf
+null/
 
 # Compiled binaries
 /bin/
@@ -30,3 +31,9 @@ vendor/
 
 # Local development tmp
 /tmp/
+
+# Private test script
+/scripts/test-private.sh
+
+# Project binary
+/vault-auth-plugin-chef

--- a/main.go
+++ b/main.go
@@ -40,12 +40,14 @@ func Factory(ctx context.Context, c *logical.BackendConfig) (logical.Backend, er
 type backend struct {
 	*framework.Backend
 	sync.RWMutex
+	SearchStore *sync.Map
 }
 
 // Backend is the factory for our backend
 func Backend(_ *logical.BackendConfig) *backend {
 	var b backend
 
+	b.SearchStore = &sync.Map{}
 	b.Backend = &framework.Backend{
 		BackendType: logical.TypeCredential,
 		AuthRenew:   b.pathAuthRenew,
@@ -60,6 +62,7 @@ func Backend(_ *logical.BackendConfig) *backend {
 			},
 			pathRole(&b),
 			pathPolicy(&b),
+			pathSearch(&b),
 		),
 	}
 	return &b

--- a/search_store.go
+++ b/search_store.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-chef/chef"
+	"github.com/hashicorp/vault/logical"
+)
+
+func (b *backend) MatchingSearches(r *logical.Request, client *chef.Client) ([]string, []string, error) {
+	policies := []string{}
+	matchedSearches := []string{}
+	searches, err := b.getSearchEntriesFromStorage(context.Background(), r)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, s := range searches {
+		ok, err := b.isNodeInSearch(r, client, s)
+		if err != nil {
+			return nil, policies, err
+		}
+		if ok {
+			policies = append(policies, s.Policies...)
+			matchedSearches = append(matchedSearches, s.Name)
+		}
+	}
+	return policies, matchedSearches, nil
+}
+
+func (b *backend) isNodeInSearch(r *logical.Request, client *chef.Client, s *ChefSearch) (bool, error) {
+	nodes, err := b.nodesForSearch(r, client, s)
+	if err != nil {
+		return false, err
+	}
+	_, ok := nodes[client.Auth.ClientName]
+	return ok, nil
+}
+
+func (b *backend) nodesForSearch(r *logical.Request, client *chef.Client, s *ChefSearch) (map[string]bool, error) {
+	st := b.SearchStore
+	name := s.Name
+	if _, ok := st.Load(name); ok {
+		return nil, nil
+	}
+
+	rs, err := client.Search.Exec("node", s.Search)
+	if err != nil {
+		return nil, fmt.Errorf("Error while executing the search: %s", err)
+	}
+
+	if len(rs.Rows) == 0 {
+		b.Logger().Warn("search \"%s\" returned 0 entries", s.Name)
+	}
+
+	nodes := make(map[string]bool, len(rs.Rows))
+	for _, nodeRaw := range rs.Rows {
+		node, ok := nodeRaw.(map[string]interface{})
+		if !ok {
+			err := fmt.Errorf("Invalid type for data returned by Chef")
+			b.Logger().Error(err.Error())
+			return nil, err
+		}
+		nameRaw, ok := node["name"]
+		if !ok {
+			err := fmt.Errorf("Name is missing from the response of Chef")
+			b.Logger().Error(err.Error())
+			return nil, err
+		}
+		name, ok := nameRaw.(string)
+		if !ok {
+			err := fmt.Errorf("Name \"%+v\" is incorrect from the response of Chef", nameRaw)
+			b.Logger().Error(err.Error())
+			return nil, err
+		}
+		nodes[name] = true
+	}
+	if s.AllowedStaleness != 0 {
+		st.Store(s.Name, nodes)
+		time.AfterFunc(s.AllowedStaleness, func() { st.Delete(s.Name) })
+	}
+	return nodes, nil
+}

--- a/searches.go
+++ b/searches.go
@@ -194,8 +194,8 @@ func (b *backend) pathSearchRead(ctx context.Context, req *logical.Request, d *f
 		Data: map[string]interface{}{
 			"policies":          search.Policies,
 			"name":              search.Name,
-			"search":            search.Search,
-			"allowed_staleness": search.AllowedStaleness,
+			"search_query":      search.Search,
+			"allowed_staleness": search.AllowedStaleness.Seconds(),
 		},
 	}
 

--- a/searches.go
+++ b/searches.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+// ChefSearch represent a Chef search query that is refreshed at each Interval time
+type ChefSearch struct {
+	Name             string
+	AllowedStaleness time.Duration
+	Search           string
+	Policies         []string
+}
+
+func pathSearch(b *backend) []*framework.Path {
+
+	return []*framework.Path{
+		{
+			Pattern: "search-refresh",
+			Fields:  map[string]*framework.FieldSchema{},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.ReadOperation: b.pathSearchRefresh,
+			},
+			ExistenceCheck:  nil,
+			HelpSynopsis:    "Remove the cache entries for saved searches.",
+			HelpDescription: "Remove the cache entries for saved searches.",
+		},
+		{
+			Pattern: "search/",
+			Fields:  map[string]*framework.FieldSchema{},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.ListOperation: b.pathSearchList,
+			},
+			ExistenceCheck:  nil,
+			HelpSynopsis:    "List all configured searches.",
+			HelpDescription: "List all configured searches.",
+		},
+		{
+			Pattern: "search/" + framework.GenericNameRegex("name"),
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeNameString,
+					Description: "The desired name for the search.",
+				},
+				"allowed_staleness": {
+					Type:        framework.TypeDurationSecond,
+					Description: "An optional cache to avoid hitting too hard on Chef servers. 0 mean no cache.",
+				},
+				"search_query": {
+					Type:        framework.TypeString,
+					Description: "The SolR search query.",
+				},
+				"policies": {
+					Type:        framework.TypeStringSlice,
+					Description: "The policies which should get associated with matching nodes.",
+				},
+			},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.ReadOperation:   b.pathSearchRead,
+				logical.CreateOperation: b.pathSearchUpdateOrCreate,
+				logical.UpdateOperation: b.pathSearchUpdateOrCreate,
+				logical.DeleteOperation: b.pathSearchDelete,
+			},
+			ExistenceCheck:  b.pathSearchExistenceCheck,
+			HelpSynopsis:    "CRUD operations on a single search",
+			HelpDescription: "Let you read, update, create or delete a single search.",
+		},
+	}
+
+}
+
+func (b *backend) getSearchEntriesFromStorage(ctx context.Context, r *logical.Request) ([]*ChefSearch, error) {
+	b.RLock()
+	b.RUnlock()
+	list, err := r.Storage.List(ctx, "search/")
+	if err != nil {
+		return nil, err
+	}
+	ret := []*ChefSearch{}
+	// ret := make([]*ChefSearch, len(list))
+	for _, sName := range list {
+		s, err := b.getSearchEntryFromStorage(ctx, r, sName)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, s)
+	}
+	return ret, nil
+}
+
+func (b *backend) getSearchEntryFromStorage(ctx context.Context, r *logical.Request, name string) (*ChefSearch, error) {
+	if name == "" {
+		b.Logger().Warn("empty name passed in getSearchEntryFromStorage")
+		return nil, fmt.Errorf("search's <name> is empty")
+	}
+
+	b.RLock()
+	defer b.RUnlock()
+
+	raw, err := r.Storage.Get(ctx, "search/"+strings.ToLower(name))
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, nil
+	}
+	search := &ChefSearch{}
+	if err := json.Unmarshal(raw.Value, search); err != nil {
+		return nil, err
+	}
+	return search, nil
+}
+
+func (b *backend) pathSearchRefresh(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.SearchStore.Range(func(key, value interface{}) bool {
+		b.SearchStore.Delete(key)
+		return true
+	})
+	return nil, nil
+}
+
+func (b *backend) pathSearchExistenceCheck(ctx context.Context, req *logical.Request, d *framework.FieldData) (bool, error) {
+	name := d.Get("name").(string)
+
+	p, err := b.getSearchEntryFromStorage(ctx, req, name)
+	return p != nil, err
+}
+
+func (b *backend) pathSearchUpdateOrCreate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	var err error
+	var s *ChefSearch
+	name := d.Get("name").(string)
+	if name == "" {
+		return logical.ErrorResponse("missing name"), nil
+	}
+	search := d.Get("search_query").(string)
+	if search == "" {
+		return logical.ErrorResponse("missing search_query"), nil
+	}
+	if req.Operation == logical.UpdateOperation {
+		s, err = b.getSearchEntryFromStorage(ctx, req, name)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		s = &ChefSearch{
+			Name:             name,
+			Policies:         []string{},
+			AllowedStaleness: 0,
+			Search:           search,
+		}
+	}
+
+	if policiesRaw, ok := d.GetOk("policies"); ok {
+		s.Policies = policiesRaw.([]string)
+	}
+
+	if intervalRaw, ok := d.GetOk("allowed_staleness"); ok {
+		s.AllowedStaleness = time.Duration(intervalRaw.(int)) * time.Second
+	}
+
+	b.Lock()
+	defer b.Unlock()
+	b.SearchStore.Delete(name)
+
+	entry, err := logical.StorageEntryJSON("search/"+strings.ToLower(name), s)
+	if err != nil {
+		return nil, err
+	}
+	return nil, req.Storage.Put(ctx, entry)
+}
+
+func (b *backend) pathSearchRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if name == "" {
+		return logical.ErrorResponse("missing name"), nil
+	}
+
+	search, err := b.getSearchEntryFromStorage(ctx, req, name)
+	if err != nil {
+		return nil, err
+	} else if search == nil {
+		return nil, nil
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"policies":          search.Policies,
+			"name":              search.Name,
+			"search":            search.Search,
+			"allowed_staleness": search.AllowedStaleness,
+		},
+	}
+
+	return resp, nil
+}
+
+func (b *backend) getSearchList(ctx context.Context, req *logical.Request) ([]string, error) {
+	b.RLock()
+	b.RUnlock()
+	return req.Storage.List(ctx, "search/")
+}
+
+func (b *backend) pathSearchList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.RLock()
+	defer b.RUnlock()
+
+	policies, err := req.Storage.List(ctx, "search/")
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(policies), nil
+}
+
+func (b *backend) pathSearchDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if name == "" {
+		return logical.ErrorResponse("missing search name"), nil
+	}
+
+	b.Lock()
+	defer b.Unlock()
+
+	if err := req.Storage.Delete(ctx, "search/"+strings.ToLower(name)); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 import "fmt"
 
-const Version = "0.2.4"
+const Version = "0.3.0"
 
 var (
 	Name      string


### PR DESCRIPTION
Add support for arbitrary chef searches with optional caching

This should make migration from data-bag settings a bit easier for large scale deployments