### PR TITLE
Allow login when no policy is configured

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"fmt"
 
@@ -11,8 +12,11 @@ import (
 )
 
 type config struct {
-	Host            string   `json:"host"`
-	DefaultPolicies []string `json:"default_policies"`
+	Host            string        `json:"host"`
+	DefaultPolicies []string      `json:"default_policies"`
+	DefaultTTL      time.Duration `json:"default_ttl" structs:"default_ttl" mapstructure:"default_ttl"`
+	DefaultMaxTTL   time.Duration `json:"default_max_ttl" structs:"default_max_ttl" mapstructure:"default_max_ttl"`
+	DefaultPeriod   time.Duration `json:"default_period" structs:"default_period" mapstructure:"default_period"`
 }
 
 func pathConfig(b *backend) *framework.Path {

--- a/login.go
+++ b/login.go
@@ -170,8 +170,17 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, nodeName, pri
 		}
 	}
 
+	// default login
 	if auth == nil {
-		return logical.ErrorResponse("no match found. permission denied."), nil
+		auth = &logical.Auth{
+			DisplayName:  nodeName,
+			LeaseOptions: logical.LeaseOptions{TTL: conf.DefaultTTL, MaxTTL: conf.DefaultMaxTTL, Renewable: true},
+			Period:       conf.DefaultPeriod,
+			Policies:     []string{"default"},
+			Metadata:     map[string]string{"node_name": nodeName},
+			GroupAliases: []*logical.Alias{},
+			InternalData: map[string]interface{}{"private_key": privateKey},
+		}
 	}
 
 	if len(conf.DefaultPolicies) > 0 {


### PR DESCRIPTION
Currently when a node logs in its policy needs to be configured for the
auth method mount point. This change allows login when the policy is not
configured with default policies ttls and periods.